### PR TITLE
Torchvision wheel for arm64

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,12 +27,15 @@ jobs:
     strategy:
       matrix:
         include:
+        # Check torch + torchvision compatibility from https://github.com/pytorch/vision?tab=readme-ov-file#installation
         - torch: '2.1.2'
           torch-wheel-tag: '2.1.2'
+          torchvision: '0.16.2'
           python: '3.11.9'
           platforms: linux/amd64,linux/arm64
         - torch: '2.1.2'
           torch-wheel-tag: '2.1.2'
+          torchvision: '0.16.2'
           python: '3.11.9-slim'
           platforms: linux/amd64,linux/arm64
         - torch: '2.1.2+cpu'
@@ -74,6 +77,7 @@ jobs:
           TORCH=${{ matrix.torch }}
           TORCH_REQUIREMENT=${{ matrix.url || format('torch=={0}', matrix.torch) }}
           TORCH_WHEEL_SOURCE=${{ matrix.torch-wheel-tag && format('{0}/torch-wheels:{1}', vars.DOCKERHUB_USERNAME, matrix.torch-wheel-tag) || 'scratch'}}
+          TORCHVISION_WHEEL_SOURCE=${{ matrix.torchvision && format('{0}/torchvision-wheels:{1}', vars.DOCKERHUB_USERNAME, matrix.torchvision) || 'scratch'}}
           EXTRA_INDEX_URL=${{ matrix.extra-index-url }}
           ${{ matrix.constraints && format('CONSTRAINTS={0}', matrix.constraints) || '' }}
         # TODO add the latest tag, maybe somehow via docker/metadata-action

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,8 @@ on:
     paths-ignore:
     - 'torch-wheel.Dockerfile'
     - '.github/workflows/torch-wheel.yml'
+    - 'torchvision-wheel.Dockerfile'
+    - '.github/workflows/torchvision-wheel.yml'
   # We want to monthly update the base image for security
   # TODO Can we avoid building the same image?
   schedule:

--- a/.github/workflows/torchvision-wheel.yml
+++ b/.github/workflows/torchvision-wheel.yml
@@ -6,7 +6,6 @@
 name: Build Torchvision Wheel
 
 on:
-  push:
   workflow_dispatch:
     inputs:
         torchvision-version:

--- a/.github/workflows/torchvision-wheel.yml
+++ b/.github/workflows/torchvision-wheel.yml
@@ -25,10 +25,10 @@ on:
             type: boolean
             default: true
 
-permissions:
-  contents: read
-  id-token: write
-  attestations: write
+# permissions:
+#   contents: read
+#   id-token: write
+#   attestations: write
 
 jobs:
   build-torchvision-wheel:
@@ -53,14 +53,14 @@ jobs:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-    - name: Discover cache path
-      # A runner can have custom variables in .env file, but they show only in
-      # the shell environment, not in the env context. Detect and set in env
-      # context with a fallback to a default path next to tool cache.
-      run: |
-          [ -z "$CACHE_PATH" ] && CACHE_PATH=$(realpath "$RUNNER_TOOL_CACHE/../_cache")
-          echo "CACHE_PATH=$CACHE_PATH" >> "$GITHUB_ENV"
-          mkdir -p "$CACHE_PATH"
+    # - name: Discover cache path
+    #   # A runner can have custom variables in .env file, but they show only in
+    #   # the shell environment, not in the env context. Detect and set in env
+    #   # context with a fallback to a default path next to tool cache.
+    #   run: |
+    #       [ -z "$CACHE_PATH" ] && CACHE_PATH=$(realpath "$RUNNER_TOOL_CACHE/../_cache")
+    #       echo "CACHE_PATH=$CACHE_PATH" >> "$GITHUB_ENV"
+    #       mkdir -p "$CACHE_PATH"
 
     - uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56 # v5.1.0
       id: push
@@ -79,21 +79,21 @@ jobs:
           org.opencontainers.image.revision=${{ github.sha }}
           org.opencontainers.image.version=${{ inputs.pytorch-version }}
         platforms: linux/amd64,linux/arm64
-        cache-from: type=local,src=${{ env.CACHE_PATH }}/torchvision-wheel
-        cache-to: type=local,dest=${{ env.CACHE_PATH }}/torchvision-wheel-new,mode=max
+        # cache-from: type=local,src=${{ env.CACHE_PATH }}/torchvision-wheel
+        # cache-to: type=local,dest=${{ env.CACHE_PATH }}/torchvision-wheel-new,mode=max
 
-    - # Temp fix
-      # https://github.com/docker/build-push-action/issues/252
-      # https://github.com/moby/buildkit/issues/1896
-      name: Move cache
-      run: |
-        rm -rf ${{ env.CACHE_PATH }}/torchvision-wheel
-        mv ${{ env.CACHE_PATH }}/torchvision-wheel-new ${{ env.CACHE_PATH }}/torchvision-wheel
+    # - # Temp fix
+    #   # https://github.com/docker/build-push-action/issues/252
+    #   # https://github.com/moby/buildkit/issues/1896
+    #   name: Move cache
+    #   run: |
+    #     rm -rf ${{ env.CACHE_PATH }}/torchvision-wheel
+    #     mv ${{ env.CACHE_PATH }}/torchvision-wheel-new ${{ env.CACHE_PATH }}/torchvision-wheel
   
-    - name: Attest
-      uses: actions/attest-build-provenance@v1
-      if: ${{ inputs.push-to-registry }}
-      with:
-        subject-name: index.docker.io/${{ vars.DOCKERHUB_USERNAME }}/torchvision-wheels
-        subject-digest: ${{ steps.push.outputs.digest }}
-        push-to-registry: true
+    # - name: Attest
+    #   uses: actions/attest-build-provenance@v1
+    #   if: ${{ inputs.push-to-registry }}
+    #   with:
+    #     subject-name: index.docker.io/${{ vars.DOCKERHUB_USERNAME }}/torchvision-wheels
+    #     subject-digest: ${{ steps.push.outputs.digest }}
+    #     push-to-registry: true

--- a/.github/workflows/torchvision-wheel.yml
+++ b/.github/workflows/torchvision-wheel.yml
@@ -47,7 +47,6 @@ jobs:
 
     - name: Log in to Docker Hub
       uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
-      if: github.ref == 'refs/heads/main'
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/torchvision-wheel.yml
+++ b/.github/workflows/torchvision-wheel.yml
@@ -47,6 +47,7 @@ jobs:
 
     - name: Log in to Docker Hub
       uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
+      if: github.ref == 'refs/heads/main'
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/torchvision-wheel.yml
+++ b/.github/workflows/torchvision-wheel.yml
@@ -1,0 +1,99 @@
+# This requires
+# vars.DOCKERHUB_USERNAME for the result image account
+# secrets.DOCKERHUB_USERNAME for the login account that pushes the image
+# secrets.DOCKERHUB_TOKEN for the login account password that pushes the image
+
+name: Build Torchvision Wheel
+
+on:
+  push:
+  workflow_dispatch:
+    inputs:
+        torchvision-version:
+            description: 'Version of torchvision to build (e.g. 0.16.2)'
+            required: true
+            default: '0.16.2'
+            type: string
+        pytorch-version:
+            description: 'Torch version (check compatibility matrix)'
+            required: true
+            default: '2.1.2'
+            type: string
+        push-to-registry:
+            description: 'Push image to registry'
+            required: true
+            type: boolean
+            default: true
+
+permissions:
+  contents: read
+  id-token: write
+  attestations: write
+
+jobs:
+  build-torchvision-wheel:
+    runs-on: [self-hosted, ARM64]
+    timeout-minutes: 1439  # GITHUB_TOKEN expires in 24 hours, so keep it just below that
+    steps:
+    - name: Print Inputs
+      run: echo "${{ toJSON(github.event.inputs) }}"
+  
+    - id: created
+      run: echo "created=$(date --utc +%Y-%m-%dT%H:%M:%SZ)" >> $GITHUB_OUTPUT
+
+    - uses: actions/checkout@v4
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
+
+    - name: Log in to Docker Hub
+      uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
+      if: github.ref == 'refs/heads/main'
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+    - name: Discover cache path
+      # A runner can have custom variables in .env file, but they show only in
+      # the shell environment, not in the env context. Detect and set in env
+      # context with a fallback to a default path next to tool cache.
+      run: |
+          [ -z "$CACHE_PATH" ] && CACHE_PATH=$(realpath "$RUNNER_TOOL_CACHE/../_cache")
+          echo "CACHE_PATH=$CACHE_PATH" >> "$GITHUB_ENV"
+          mkdir -p "$CACHE_PATH"
+
+    - uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56 # v5.1.0
+      id: push
+      with:
+        context: .
+        file: ./torchvision-wheel.Dockerfile
+        push: ${{ inputs.push-to-registry || false }}
+        build-args: |
+          TORCHVISION_VERSION=${{ inputs.torchvision-version }}
+          TORCH_WHEEL_SOURCE=${{ vars.DOCKERHUB_USERNAME }}/torch-wheels:${{ inputs.pytorch-version }}
+          PYTORCH_VERSION=${{ inputs.pytorch-version }}
+        tags: |
+            ${{ vars.DOCKERHUB_USERNAME }}/torchvision-wheels:${{ inputs.torchvision-version }}
+        labels: |
+          org.opencontainers.image.created=${{ steps.created.outputs.created }}
+          org.opencontainers.image.revision=${{ github.sha }}
+          org.opencontainers.image.version=${{ inputs.pytorch-version }}
+        platforms: linux/amd64,linux/arm64
+        cache-from: type=local,src=${{ env.CACHE_PATH }}/torchvision-wheel
+        cache-to: type=local,dest=${{ env.CACHE_PATH }}/torchvision-wheel-new,mode=max
+
+    - # Temp fix
+      # https://github.com/docker/build-push-action/issues/252
+      # https://github.com/moby/buildkit/issues/1896
+      name: Move cache
+      run: |
+        rm -rf ${{ env.CACHE_PATH }}/torchvision-wheel
+        mv ${{ env.CACHE_PATH }}/torchvision-wheel-new ${{ env.CACHE_PATH }}/torchvision-wheel
+  
+    - name: Attest
+      uses: actions/attest-build-provenance@v1
+      if: ${{ inputs.push-to-registry }}
+      with:
+        subject-name: index.docker.io/${{ vars.DOCKERHUB_USERNAME }}/torchvision-wheels
+        subject-digest: ${{ steps.push.outputs.digest }}
+        push-to-registry: true

--- a/.github/workflows/torchvision-wheel.yml
+++ b/.github/workflows/torchvision-wheel.yml
@@ -24,10 +24,10 @@ on:
             type: boolean
             default: true
 
-# permissions:
-#   contents: read
-#   id-token: write
-#   attestations: write
+permissions:
+  contents: read
+  id-token: write
+  attestations: write
 
 jobs:
   build-torchvision-wheel:
@@ -52,14 +52,14 @@ jobs:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-    # - name: Discover cache path
-    #   # A runner can have custom variables in .env file, but they show only in
-    #   # the shell environment, not in the env context. Detect and set in env
-    #   # context with a fallback to a default path next to tool cache.
-    #   run: |
-    #       [ -z "$CACHE_PATH" ] && CACHE_PATH=$(realpath "$RUNNER_TOOL_CACHE/../_cache")
-    #       echo "CACHE_PATH=$CACHE_PATH" >> "$GITHUB_ENV"
-    #       mkdir -p "$CACHE_PATH"
+    - name: Discover cache path
+      # A runner can have custom variables in .env file, but they show only in
+      # the shell environment, not in the env context. Detect and set in env
+      # context with a fallback to a default path next to tool cache.
+      run: |
+          [ -z "$CACHE_PATH" ] && CACHE_PATH=$(realpath "$RUNNER_TOOL_CACHE/../_cache")
+          echo "CACHE_PATH=$CACHE_PATH" >> "$GITHUB_ENV"
+          mkdir -p "$CACHE_PATH"
 
     - uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56 # v5.1.0
       id: push
@@ -78,21 +78,21 @@ jobs:
           org.opencontainers.image.revision=${{ github.sha }}
           org.opencontainers.image.version=${{ inputs.pytorch-version }}
         platforms: linux/amd64,linux/arm64
-        # cache-from: type=local,src=${{ env.CACHE_PATH }}/torchvision-wheel
-        # cache-to: type=local,dest=${{ env.CACHE_PATH }}/torchvision-wheel-new,mode=max
+        cache-from: type=local,src=${{ env.CACHE_PATH }}/torchvision-wheel
+        cache-to: type=local,dest=${{ env.CACHE_PATH }}/torchvision-wheel-new,mode=max
 
-    # - # Temp fix
-    #   # https://github.com/docker/build-push-action/issues/252
-    #   # https://github.com/moby/buildkit/issues/1896
-    #   name: Move cache
-    #   run: |
-    #     rm -rf ${{ env.CACHE_PATH }}/torchvision-wheel
-    #     mv ${{ env.CACHE_PATH }}/torchvision-wheel-new ${{ env.CACHE_PATH }}/torchvision-wheel
+    - # Temp fix
+      # https://github.com/docker/build-push-action/issues/252
+      # https://github.com/moby/buildkit/issues/1896
+      name: Move cache
+      run: |
+        rm -rf ${{ env.CACHE_PATH }}/torchvision-wheel
+        mv ${{ env.CACHE_PATH }}/torchvision-wheel-new ${{ env.CACHE_PATH }}/torchvision-wheel
   
-    # - name: Attest
-    #   uses: actions/attest-build-provenance@v1
-    #   if: ${{ inputs.push-to-registry }}
-    #   with:
-    #     subject-name: index.docker.io/${{ vars.DOCKERHUB_USERNAME }}/torchvision-wheels
-    #     subject-digest: ${{ steps.push.outputs.digest }}
-    #     push-to-registry: true
+    - name: Attest
+      uses: actions/attest-build-provenance@v1
+      if: ${{ inputs.push-to-registry }}
+      with:
+        subject-name: index.docker.io/${{ vars.DOCKERHUB_USERNAME }}/torchvision-wheels
+        subject-digest: ${{ steps.push.outputs.digest }}
+        push-to-registry: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,12 +5,14 @@ ARG TORCH=2.1.2
 ARG TORCH_REQUIREMENT="torch==${TORCH}"
 ARG EXTRA_INDEX_URL
 ARG TORCH_WHEEL_SOURCE="scratch"
+ARG TORCHVISION_WHEEL_SOURCE="scratch"
 ARG CREATED
 ARG SOURCE_COMMIT
 ARG CONSTRAINTS=constraints.txt
 
 # Using variable in RUN --mount=from gives error 'from' doesn't support variable expansion, define alias stage instead
-FROM ${TORCH_WHEEL_SOURCE} as wheel-image
+FROM ${TORCH_WHEEL_SOURCE} as torch-wheel-image
+FROM ${TORCHVISION_WHEEL_SOURCE} as torchvision-wheel-image
 
 
 FROM python:${PYTHON}
@@ -43,20 +45,29 @@ ARG CONSTRAINTS
 ARG TORCH_REQUIREMENT
 ARG EXTRA_INDEX_URL
 RUN --mount=src=${CONSTRAINTS},target=/tmp/constraints.txt \
-    --mount=from=wheel-image,src=/,target=/tmp/torch-wheels \
+    --mount=from=torch-wheel-image,src=/,target=/tmp/torch-wheels \
+    --mount=from=torchvision-wheel-image,src=/,target=/tmp/torchvision-wheels \
     <<NUR
-    set -ex
-    # If any wheel files exist, install from those, otherwise install from PyPi
+    set -ex \
+    # If any torch wheel files exist, install from those, otherwise install from PyPi
     if ls /tmp/torch-wheels/*.whl 1> /dev/null 2>&1
     then
         TORCH_INSTALL="/tmp/torch-wheels/*.whl"
     else
         TORCH_INSTALL=${TORCH_REQUIREMENT}
+    fi \
+    # If any torchvision wheel files exist, install them
+    if ls /tmp/torchvision-wheels/*.whl 1> /dev/null 2>&1
+    then
+        TORCHVISION_INSTALL="/tmp/torchvision-wheels/*.whl"
+    else
+        TORCHVISION_INSTALL=""
     fi
+
     pip install --no-cache-dir \
         -c /tmp/constraints.txt \
         ${EXTRA_INDEX_URL:+--extra-index-url ${EXTRA_INDEX_URL}} \
-        ${TORCH_INSTALL}
+        ${TORCH_INSTALL} ${TORCHVISION_INSTALL}
 NUR
 
 # nvidia-docker plugin uses these environment variables to provide services

--- a/torchvision-wheel.Dockerfile
+++ b/torchvision-wheel.Dockerfile
@@ -1,0 +1,1 @@
+FROM scratch

--- a/torchvision-wheel.Dockerfile
+++ b/torchvision-wheel.Dockerfile
@@ -51,8 +51,6 @@ RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1
 RUN pip3 uninstall -y setuptools && pip3 install setuptools==69.5.1
 RUN pip3 uninstall -y numpy && pip3 install numpy
 
-
-# COPY --from=torch-wheel-image /torch-*.whl /opt/
 ARG PYTORCH_VERSION
 
 # Install PyTorch dependency
@@ -67,13 +65,8 @@ RUN --mount=from=torch-wheel-image,src=/,target=/opt/ \
         TORCH_INSTALL="torch==${PYTORCH_VERSION}"
     fi
     pip3 install --no-cache-dir ${TORCH_INSTALL}
+    pip freeze
 NUR
-
-# TODO: debug, remove
-RUN pip3 freeze
-
-
-# RUN pip3 install --verbose /opt/torch-*.whl
 
 WORKDIR /opt/torchvision
 
@@ -82,8 +75,6 @@ ARG TORCHVISION_VERSION
 RUN git clone --branch "v${TORCHVISION_VERSION}" --recursive --depth=1 https://github.com/pytorch/vision /opt/torchvision
 
 RUN git checkout "v${TORCHVISION_VERSION}"
-
-# RUN cd
 
 # Both CUDA_HOME & TORCH_CUDA_ARCH_LIST are needed
 RUN cd /opt/torchvision && \

--- a/torchvision-wheel.Dockerfile
+++ b/torchvision-wheel.Dockerfile
@@ -1,1 +1,117 @@
-FROM scratch
+# Compatibility matrix for torch+torchvision: https://github.com/pytorch/vision
+ARG TORCHVISION_VERSION=0.16.2
+ARG PYTORCH_VERSION=2.1.2
+ARG TORCH_WHEEL_SOURCE="scratch"
+ARG ARM_BASE_IMAGE=nvcr.io/nvidia/l4t-cuda:12.2.12-devel
+
+
+# Using variable in RUN --mount=from gives error 'from' doesn't support variable expansion, define alias stage instead
+FROM ${TORCH_WHEEL_SOURCE} as torch-wheel-image
+
+
+# Builder stage for x86 wheel, just a dummy for now
+FROM scratch as amd64
+
+# Builder stage for arm64 wheel
+FROM ${ARM_BASE_IMAGE} as arm64
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV PYTHONUNBUFFERED=1
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        libopenblas-dev \
+        libopenmpi-dev \
+        openmpi-bin \
+        openmpi-common \
+        gfortran \
+        libomp-dev \
+        git \
+        python3.11 \
+        python3.11-dev \
+        libpng-dev \
+        libjpeg-turbo8-dev \
+        zlib1g-dev \
+    && rm -rf /var/lib/apt/lists/* \
+    && apt-get clean
+
+RUN apt-get update && apt-get install python3.11-distutils
+
+RUN wget https://bootstrap.pypa.io/get-pip.py
+
+RUN python3.11 get-pip.py
+
+RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1 && \
+    update-alternatives --set python3 /usr/bin/python3.11 && \
+    update-alternatives --install /usr/bin/pip pip /usr/local/bin/pip3.11 1 && \
+    update-alternatives --set pip /usr/local/bin/pip3.11
+
+# Deprecation of some packages in setuptools version >70, so we downgrade to older version
+# https://github.com/aws-neuron/aws-neuron-sdk/issues/893
+RUN pip3 uninstall -y setuptools && pip3 install setuptools==69.5.1
+RUN pip3 uninstall -y numpy && pip3 install numpy
+
+
+# COPY --from=torch-wheel-image /torch-*.whl /opt/
+ARG PYTORCH_VERSION
+
+# Install PyTorch dependency
+RUN --mount=from=torch-wheel-image,src=/,target=/opt/ \
+    <<NUR
+    set -ex \
+    # If any wheel files exist, install from those, otherwise install from PyPi
+    if ls /opt/*.whl 1> /dev/null 2>&1
+    then
+        TORCH_INSTALL="/opt/*.whl"
+    else
+        TORCH_INSTALL="torch==${PYTORCH_VERSION}"
+    fi
+    pip3 install --no-cache-dir ${TORCH_INSTALL}
+NUR
+
+# TODO: debug, remove
+RUN pip3 freeze
+
+
+# RUN pip3 install --verbose /opt/torch-*.whl
+
+WORKDIR /opt/torchvision
+
+ARG TORCHVISION_VERSION
+
+RUN git clone --branch "v${TORCHVISION_VERSION}" --recursive --depth=1 https://github.com/pytorch/vision /opt/torchvision
+
+RUN git checkout "v${TORCHVISION_VERSION}"
+
+# RUN cd
+
+# Both CUDA_HOME & TORCH_CUDA_ARCH_LIST are needed
+RUN cd /opt/torchvision && \
+    export FORCE_CUDA=1 && \
+    export CUDA_HOME=/usr/local/cuda-12.2 && \
+    export TORCH_CUDA_ARCH_LIST="7.2;8.7" && \
+    export TORCHVISION_USE_PNG=1 && \
+    export TORCHVISION_USE_JPEG=1 && \
+    python3 setup.py --verbose bdist_wheel --dist-dir /
+
+RUN pip3 install auditwheel
+
+RUN apt install -y patchelf
+
+# Needed to correctly link dynamic libraries in the wheel
+# https://github.com/pytorch/vision/blob/main/packaging/wheel/relocate.py
+RUN cd /opt/torchvision/packaging/wheel/ && \
+  python3 relocate.py
+
+WORKDIR /home
+
+# RUN pip3 install --no-cache-dir --verbose /opt/torchvision/dist/*.whl
+
+
+# Alias to copy files from in next stage
+FROM ${TARGETARCH} as wheels
+
+# We only want to store the wheel in the final image
+FROM scratch as wheel-container
+
+COPY --from=wheels /*.whl /


### PR DESCRIPTION
- We want to build torchvision wheel from source for ARM64 with CUDA support
- Using torchvision installation from PyPi generated some warnings on Jetson platform, this fixes the issue
- Add workflow to build torchvision-wheel (.github/workflows/torchvision-wheel.yml)
- Add Dockerfile for building torchvision wheel (torchvision-wheel.Dockerfile)
- Update main workflow to install torchvision wheel for ARM


Warning encountered when using torchvision from PyPi:
```/usr/local/lib/python3.11/site-packages/torchvision/io/image.py:13: UserWarning: Failed to load image Python extension: '/usr/local/lib/python3.11/site-packages/torchvision/image.so: undefined symbol: _ZN5torch3jit17parseSchemaOrNameERKSs'If you don't plan on using image functionality from `torchvision.io`, you can ignore this warning. Otherwise, there might be something wrong with your environment. Did you have `libjpeg` or `libpng` installed before building `torchvision` from source?```